### PR TITLE
Fix calico deployment for version >= 3.23

### DIFF
--- a/base/apiserver.yaml
+++ b/base/apiserver.yaml
@@ -39,7 +39,7 @@ spec:
         env:
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: calico/apiserver:v3.23.2
+        image: calico/apiserver:v3.23.3
         livenessProbe:
           httpGet:
             path: /version

--- a/base/calico-env-patch.yaml
+++ b/base/calico-env-patch.yaml
@@ -1,0 +1,13 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: calico-node
+spec:
+  template:
+    spec:
+      containers:
+        - name: calico-node
+          env:
+            # Use `sv -w 60 1 felix` inside the container to get a profile
+            - name: FELIX_DebugMemoryProfilePath
+              value: "/tmp/felix-mem.pb.gz"

--- a/base/calico-init-patch.yaml
+++ b/base/calico-init-patch.yaml
@@ -1,0 +1,26 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: calico-node
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: install-cni
+          env:
+            # Use Kubernetes service host and port as specified in calico config
+            # (configMap) to avoid relying on kube-proxy mechanisms. We need
+            # this since we run kube-proxy as a calico sidecar and since v3.23
+            # calico init needs to query the apiserver. Thus, in fresh nodes it
+            # will not be able to route requests to apiservers until kube-proxy
+            # is up and running.
+            - name: KUBERNETES_SERVICE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  key: kubernetes_service_host
+                  name: calico-config
+            - name: KUBERNETES_SERVICE_PORT
+              valueFrom:
+                configMapKeyRef:
+                  key: kubernetes_service_port
+                  name: calico-config

--- a/base/calico-resources-patch.yaml
+++ b/base/calico-resources-patch.yaml
@@ -7,10 +7,6 @@ spec:
     spec:
       containers:
         - name: calico-node
-          env:
-            # Use `sv -w 60 1 felix` inside the container to get a profile
-            - name: FELIX_DebugMemoryProfilePath
-              value: "/tmp/felix-mem.pb.gz"
           resources:
             requests:
               cpu: 250m

--- a/base/calico-typha.yaml
+++ b/base/calico-typha.yaml
@@ -4268,7 +4268,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: docker.io/calico/typha:v3.23.2
+      - image: docker.io/calico/typha:v3.23.3
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -4381,7 +4381,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.23.2
+          image: docker.io/calico/cni:v3.23.3
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -4424,7 +4424,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.23.2
+          image: docker.io/calico/node:v3.23.3
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4641,7 +4641,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.23.2
+          image: docker.io/calico/kube-controllers:v3.23.3
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -7,5 +7,7 @@ resources:
   - calico-typha.yaml
   - felix-metrics-svc.yaml
 patchesStrategicMerge:
-  - calico-patch.yaml
+  - calico-env-patch.yaml
+  - calico-init-patch.yaml
+  - calico-resources-patch.yaml
   - apiserver-patch.yaml


### PR DESCRIPTION
We need to provide init container with an address for kube apiservers, since we
cannot rely on kube-proxy routes for fresh nodes.
This also updates to the latest available image and splits patches in more
specific files.