### PR TITLE
Configure IP autodetection method to get address from kube

### DIFF
--- a/base/calico-env-patch.yaml
+++ b/base/calico-env-patch.yaml
@@ -11,3 +11,5 @@ spec:
             # Use `sv -w 60 1 felix` inside the container to get a profile
             - name: FELIX_DebugMemoryProfilePath
               value: "/tmp/felix-mem.pb.gz"
+            - name: IP_AUTODETECTION_METHOD
+              value: kubernetes-internal-ip


### PR DESCRIPTION
Use the kubernetes-internal-ip method which will select the first internal IP address listed in the Kubernetes node’s Status.Addresses field: https://projectcalico.docs.tigera.io/reference/node/configuration#ip-autodetection-methods This will offer an extra protection in cases where we play with the hosts network interfaces