### PR TITLE
Do not rely on Kubernetes Node Resources for IP detection

### DIFF
--- a/base/calico-env-patch.yaml
+++ b/base/calico-env-patch.yaml
@@ -11,5 +11,3 @@ spec:
             # Use `sv -w 60 1 felix` inside the container to get a profile
             - name: FELIX_DebugMemoryProfilePath
               value: "/tmp/felix-mem.pb.gz"
-            - name: IP_AUTODETECTION_METHOD
-              value: kubernetes-internal-ip


### PR DESCRIPTION
Looking at Kubernetes node's `Status.Addresses` introduces a dependency between calico-node and cloud-controller-managers. Let's fall back to the default IP autodetection method:

By default, Calico uses the first-found method; the first valid IP address on the first interface (excluding local interfaces such as the docker bridge) https://docs.tigera.io/calico/latest/networking/ipam/ip-autodetection